### PR TITLE
Support both json/csv files for identity loading

### DIFF
--- a/cli/update_identity.go
+++ b/cli/update_identity.go
@@ -2,14 +2,21 @@ package cli
 
 import (
 	"encoding/csv"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/figment-networks/mina-indexer/config"
 	"github.com/figment-networks/mina-indexer/store"
 	"github.com/sirupsen/logrus"
 )
+
+type identity struct {
+	PublicKey string `json:"public_key"`
+	Name      string `json:"name"`
+}
 
 func runUpdateIdentity(cfg *config.Config) error {
 	if cfg.IdentityFile == "" {
@@ -24,33 +31,49 @@ func runUpdateIdentity(cfg *config.Config) error {
 
 	db.SetDebugMode(true)
 
-	f, err := os.Open(cfg.IdentityFile)
+	return readIdentityFile(cfg.IdentityFile, func(item identity) {
+		err := db.Validators.UpdateIdentity(item.PublicKey, item.Name)
+
+		logrus.
+			WithField("pk", item.PublicKey).
+			WithField("name", item.Name).
+			WithError(err).
+			Info("identity updated")
+	})
+}
+
+func readIdentityFile(src string, handler func(identity)) error {
+	f, err := os.Open(src)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
 
-	reader := csv.NewReader(f)
+	switch filepath.Ext(filepath.Base(src)) {
+	case ".csv":
+		reader := csv.NewReader(f)
 
-	for {
-		row, err := reader.Read()
-		if err != nil {
-			if err == io.EOF {
-				break
+		for {
+			row, err := reader.Read()
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				return err
 			}
+
+			handler(identity{row[0], row[1]})
+		}
+	case ".json":
+		identities := []identity{}
+		if err := json.NewDecoder(f).Decode(&identities); err != nil {
 			return err
 		}
-
-		if err := db.Validators.UpdateIdentity(row[1], row[0]); err != nil {
-			logrus.
-				WithField("pk", row[1]).
-				WithField("name", row[0]).
-				WithError(err).
-				Error("cant update validator identity")
-			continue
+		for _, identityItem := range identities {
+			handler(identityItem)
 		}
-
-		logrus.WithField("pk", row[1]).WithField("name", row[0]).Info("identity updated")
+	default:
+		return errors.New("unsupports file extension")
 	}
 
 	return nil

--- a/cli/update_identity.go
+++ b/cli/update_identity.go
@@ -79,7 +79,7 @@ func readIdentityFile(src string, handler func(identity) error) error {
 			}
 		}
 	default:
-		return errors.New("unsupports file extension")
+		return errors.New("unsupported file extension")
 	}
 
 	return nil


### PR DESCRIPTION
Records formats:

- CSV: `key,name`
- JSON: `{"public_key": "...", "name": "..."}`