### PR TITLE
Add new /ledgers endpoint to retrieve a list of all existing ledgers

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -58,6 +58,7 @@ func (s *Server) initRoutes() {
 	s.GET("/transactions", s.GetTransactions)
 	s.GET("/transactions/:id", s.GetTransaction)
 	s.GET("/accounts/:id", s.GetAccount)
+	s.GET("/ledgers", s.GetLedgers)
 	s.GET("/ledger", s.GetLedger)
 }
 
@@ -418,6 +419,15 @@ func (s *Server) GetAccount(c *gin.Context) {
 	}
 
 	jsonOk(c, acc)
+}
+
+// GetLedgers returns a list of all existing ledgers
+func (s *Server) GetLedgers(c *gin.Context) {
+	ledgers, err := s.db.Staking.AllLedgers()
+	if shouldReturn(c, err) {
+		return
+	}
+	jsonOk(c, ledgers)
 }
 
 // GetLedger records the current epoch ledger records

--- a/store/staking.go
+++ b/store/staking.go
@@ -57,6 +57,19 @@ func (s StakingStore) FindLedger(epoch int) (*model.Ledger, error) {
 	return ledger, checkErr(err)
 }
 
+// AllLedgers returns all existing ledgers
+func (s StakingStore) AllLedgers() ([]model.Ledger, error) {
+	result := []model.Ledger{}
+
+	err := s.db.
+		Model(&model.Ledger{}).
+		Order("epoch ASC").
+		Find(&result).
+		Error
+
+	return result, err
+}
+
 // LastLedger returns the most recent ledger record
 func (s StakingStore) LastLedger() (*model.Ledger, error) {
 	ledger := &model.Ledger{}


### PR DESCRIPTION
Adds a new /ledgers endpoint with an example output:

```json
[
  {
    "time": "2021-03-17T12:56:17.635536-05:00",
    "epoch": 0,
    "entries_count": 1676,
    "staked_amount": "805385692840039237",
    "delegations_count": 1184,
    "delegations_amount": "768891177380302665"
  }
]
```