### PR TITLE
Fix/ledger timing vesting increment type

### DIFF
--- a/model/ledger.go
+++ b/model/ledger.go
@@ -21,17 +21,17 @@ func (Ledger) TableName() string {
 }
 
 type LedgerEntry struct {
-	ID                          int           `json:"-"`
-	LedgerID                    int           `json:"-"`
-	PublicKey                   string        `json:"public_key"`
-	Delegate                    string        `json:"delegate"`
-	Delegation                  bool          `json:"delegation"`
-	Balance                     types.Amount  `json:"balance"`
-	TimingInitialMinimumBalance types.Amount  `json:"timing_initial_minimum_balance"`
-	TimingCliffTime             *int          `json:"timing_cliff_time"`
-	TimingCliffAmount           types.Amount  `json:"timing_cliff_amount"`
-	TimingVestingPeriod         *int          `json:"timing_vesting_period"`
-	TimingVestingIncrement      *types.Amount `json:"timing_vesting_increment"`
+	ID                          int          `json:"-"`
+	LedgerID                    int          `json:"-"`
+	PublicKey                   string       `json:"public_key"`
+	Delegate                    string       `json:"delegate"`
+	Delegation                  bool         `json:"delegation"`
+	Balance                     types.Amount `json:"balance"`
+	TimingInitialMinimumBalance types.Amount `json:"timing_initial_minimum_balance"`
+	TimingCliffTime             *int         `json:"timing_cliff_time"`
+	TimingCliffAmount           types.Amount `json:"timing_cliff_amount"`
+	TimingVestingPeriod         *int         `json:"timing_vesting_period"`
+	TimingVestingIncrement      types.Amount `json:"timing_vesting_increment"`
 }
 
 func (LedgerEntry) TableName() string {

--- a/model/ledger.go
+++ b/model/ledger.go
@@ -21,17 +21,17 @@ func (Ledger) TableName() string {
 }
 
 type LedgerEntry struct {
-	ID                          int          `json:"-"`
-	LedgerID                    int          `json:"-"`
-	PublicKey                   string       `json:"public_key"`
-	Delegate                    string       `json:"delegate"`
-	Delegation                  bool         `json:"delegation"`
-	Balance                     types.Amount `json:"balance"`
-	TimingInitialMinimumBalance types.Amount `json:"timing_initial_minimum_balance"`
-	TimingCliffTime             *int         `json:"timing_cliff_time"`
-	TimingCliffAmount           types.Amount `json:"timing_cliff_amount"`
-	TimingVestingPeriod         *int         `json:"timing_vesting_period"`
-	TimingVestingIncrement      *int         `json:"timing_vesting_increment"`
+	ID                          int           `json:"-"`
+	LedgerID                    int           `json:"-"`
+	PublicKey                   string        `json:"public_key"`
+	Delegate                    string        `json:"delegate"`
+	Delegation                  bool          `json:"delegation"`
+	Balance                     types.Amount  `json:"balance"`
+	TimingInitialMinimumBalance types.Amount  `json:"timing_initial_minimum_balance"`
+	TimingCliffTime             *int          `json:"timing_cliff_time"`
+	TimingCliffAmount           types.Amount  `json:"timing_cliff_amount"`
+	TimingVestingPeriod         *int          `json:"timing_vesting_period"`
+	TimingVestingIncrement      *types.Amount `json:"timing_vesting_increment"`
 }
 
 func (LedgerEntry) TableName() string {

--- a/model/mapper/ledger.go
+++ b/model/mapper/ledger.go
@@ -54,9 +54,17 @@ func Ledger(tip *graph.Block, records []archive.StakingInfo) (*LedgerData, error
 		}
 
 		if timing := record.Timing; timing != nil {
-			cliffTime, _ := util.ParseInt(timing.CliffTime)
-			vestingIncrement, _ := util.ParseInt(timing.VestingIncrement)
-			vestingPeriod, _ := util.ParseInt(timing.VestingPeriod)
+			cliffTime, err := util.ParseInt(timing.CliffTime)
+			if err != nil {
+				return nil, err
+			}
+
+			vestingPeriod, err := util.ParseInt(timing.VestingPeriod)
+			if err != nil {
+				return nil, err
+			}
+
+			vestingIncrement := types.NewFloatAmount(timing.VestingIncrement)
 
 			entry.TimingInitialMinimumBalance = types.NewFloatAmount(timing.InitialMinimumBalance)
 			entry.TimingCliffAmount = types.NewFloatAmount(timing.CliffAmount)

--- a/model/mapper/ledger.go
+++ b/model/mapper/ledger.go
@@ -64,12 +64,10 @@ func Ledger(tip *graph.Block, records []archive.StakingInfo) (*LedgerData, error
 				return nil, err
 			}
 
-			vestingIncrement := types.NewFloatAmount(timing.VestingIncrement)
-
 			entry.TimingInitialMinimumBalance = types.NewFloatAmount(timing.InitialMinimumBalance)
 			entry.TimingCliffAmount = types.NewFloatAmount(timing.CliffAmount)
 			entry.TimingCliffTime = &cliffTime
-			entry.TimingVestingIncrement = &vestingIncrement
+			entry.TimingVestingIncrement = types.NewFloatAmount(timing.VestingIncrement)
 			entry.TimingVestingPeriod = &vestingPeriod
 		}
 

--- a/model/mapper/ledger_test.go
+++ b/model/mapper/ledger_test.go
@@ -5,10 +5,11 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/figment-networks/mina-indexer/client/archive"
 	"github.com/figment-networks/mina-indexer/client/graph"
 	"github.com/figment-networks/mina-indexer/model/types"
-	"github.com/stretchr/testify/assert"
 )
 
 var (

--- a/model/mapper/ledger_test.go
+++ b/model/mapper/ledger_test.go
@@ -11,6 +11,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	graphTip = &graph.Block{
+		ProtocolState: &graph.ProtocolState{
+			ConsensusState: &graph.ConsensusState{
+				Epoch: "10",
+			},
+		},
+	}
+)
+
 func readLedgerFromFile(path string) []archive.StakingInfo {
 	f, err := os.Open(path)
 	if err != nil {
@@ -29,15 +39,7 @@ func readLedgerFromFile(path string) []archive.StakingInfo {
 func TestLedger(t *testing.T) {
 	entries := readLedgerFromFile("../../test/fixtures/ledger.json")
 
-	block := &graph.Block{
-		ProtocolState: &graph.ProtocolState{
-			ConsensusState: &graph.ConsensusState{
-				Epoch: "10",
-			},
-		},
-	}
-
-	ledgerData, err := Ledger(block, entries)
+	ledgerData, err := Ledger(graphTip, entries)
 	ledger := ledgerData.Ledger
 
 	assert.NoError(t, err)
@@ -65,4 +67,11 @@ func TestLedger(t *testing.T) {
 	assert.Equal(t, types.NewFloatAmount("0").String(), entry.TimingCliffAmount.String())
 	assert.Equal(t, 1, *entry.TimingVestingPeriod)
 	assert.Equal(t, types.NewFloatAmount("70.730534765").String(), entry.TimingVestingIncrement.String())
+}
+
+func TestLedgerError(t *testing.T) {
+	entries := readLedgerFromFile("../../test/fixtures/ledger_with_error.json")
+	_, err := Ledger(graphTip, entries)
+	assert.Error(t, err)
+	assert.Equal(t, `strconv.ParseInt: parsing "some wrong value": invalid syntax`, err.Error())
 }

--- a/model/mapper/ledger_test.go
+++ b/model/mapper/ledger_test.go
@@ -1,0 +1,68 @@
+package mapper
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/figment-networks/mina-indexer/client/archive"
+	"github.com/figment-networks/mina-indexer/client/graph"
+	"github.com/figment-networks/mina-indexer/model/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func readLedgerFromFile(path string) []archive.StakingInfo {
+	f, err := os.Open(path)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	result := []archive.StakingInfo{}
+	if err := json.NewDecoder(f).Decode(&result); err != nil {
+		panic(err)
+	}
+
+	return result
+}
+
+func TestLedger(t *testing.T) {
+	entries := readLedgerFromFile("../../test/fixtures/ledger.json")
+
+	block := &graph.Block{
+		ProtocolState: &graph.ProtocolState{
+			ConsensusState: &graph.ConsensusState{
+				Epoch: "10",
+			},
+		},
+	}
+
+	ledgerData, err := Ledger(block, entries)
+	ledger := ledgerData.Ledger
+
+	assert.NoError(t, err)
+	assert.Equal(t, 3, ledger.EntriesCount)
+	assert.Equal(t, 10, ledger.Epoch)
+	assert.Equal(t, 3, len(ledgerData.Entries))
+
+	entry := ledgerData.Entries[0]
+	assert.Equal(t, types.NewFloatAmount("4651").String(), entry.TimingInitialMinimumBalance.String())
+	assert.Equal(t, 86400, *entry.TimingCliffTime)
+	assert.Equal(t, types.NewFloatAmount("4651").String(), entry.TimingCliffAmount.String())
+	assert.Equal(t, 1, *entry.TimingVestingPeriod)
+	assert.Equal(t, types.NewFloatAmount("0").String(), entry.TimingVestingIncrement.String())
+
+	entry = ledgerData.Entries[1]
+	assert.Equal(t, types.NewFloatAmount("66000").String(), entry.TimingInitialMinimumBalance.String())
+	assert.Equal(t, 172800, *entry.TimingCliffTime)
+	assert.Equal(t, types.NewFloatAmount("16500").String(), entry.TimingCliffAmount.String())
+	assert.Equal(t, 1, *entry.TimingVestingPeriod)
+	assert.Equal(t, types.NewFloatAmount("0.095486111").String(), entry.TimingVestingIncrement.String())
+
+	entry = ledgerData.Entries[2]
+	assert.Equal(t, types.NewFloatAmount("15277795.5092651").String(), entry.TimingInitialMinimumBalance.String())
+	assert.Equal(t, 43200, *entry.TimingCliffTime)
+	assert.Equal(t, types.NewFloatAmount("0").String(), entry.TimingCliffAmount.String())
+	assert.Equal(t, 1, *entry.TimingVestingPeriod)
+	assert.Equal(t, types.NewFloatAmount("70.730534765").String(), entry.TimingVestingIncrement.String())
+}

--- a/store/migrations/016_change_vesting_increment_field_type.sql
+++ b/store/migrations/016_change_vesting_increment_field_type.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE ledger_entries ALTER COLUMN timing_vesting_increment TYPE CHAIN_CURRENCY;
+
+-- +goose Down
+ALTER TABLE ledger_entries ALTER COLUMN timing_vesting_increment TYPE INTEGER;

--- a/test/fixtures/ledger.json
+++ b/test/fixtures/ledger.json
@@ -1,0 +1,74 @@
+[
+  {
+    "pk": "B62qqnZWjM68fMq7jVR19fGDnrigtYX9WZ14enXFiLZkE13WDe4aLy3",
+    "balance": "4793.953311237",
+    "delegate": "B62qorXXHv971Kvnq91TkvWsRAvMCB8yszCX6yUhpyZseKcibSZSDSF",
+    "timing": {
+      "initial_minimum_balance": "4651",
+      "cliff_time": "86400",
+      "cliff_amount": "4651",
+      "vesting_period": "1",
+      "vesting_increment": "0"
+    },
+    "token": "1",
+    "token_permissions": {},
+    "receipt_chain_hash": "2mzbV7WevxLuchs2dAMY4vQBS6XttnCUF8Hvks4XNBQ5qiSGGBQe",
+    "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
+    "permissions": {
+      "stake": true,
+      "edit_state": "signature",
+      "send": "signature",
+      "set_delegate": "signature",
+      "set_permissions": "signature",
+      "set_verification_key": "signature"
+    }
+  },
+  {
+    "pk": "B62qkUQyaxfFNtoMXoZwa6Ar9pXPzhzeWCEsvvN1Eb6KfDeP5PgXJFv",
+    "balance": "68018.061360456",
+    "delegate": "B62qrCz3ehCqi8Pn8y3vWC9zYEB9RKsidauv15DeZxhzkxL3bKeba5h",
+    "timing": {
+      "initial_minimum_balance": "66000",
+      "cliff_time": "172800",
+      "cliff_amount": "16500",
+      "vesting_period": "1",
+      "vesting_increment": "0.095486111"
+    },
+    "token": "1",
+    "token_permissions": {},
+    "receipt_chain_hash": "2mzbV7WevxLuchs2dAMY4vQBS6XttnCUF8Hvks4XNBQ5qiSGGBQe",
+    "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
+    "permissions": {
+      "stake": true,
+      "edit_state": "signature",
+      "send": "signature",
+      "set_delegate": "signature",
+      "set_permissions": "signature",
+      "set_verification_key": "signature"
+    }
+  },
+  {
+    "pk": "B62qr2ingZ5sWoyEPFazcQkYYWx99mLqs84pPYSdpWkRCKsg9Gz4kTz",
+    "balance": "15277797.5103651",
+    "delegate": "B62qjJ2eGwj1mmB6XThCV2m9JxUqJGXLqwyirxTbzBanzs2ThazD1Gy",
+    "timing": {
+      "initial_minimum_balance": "15277795.5092651",
+      "cliff_time": "43200",
+      "cliff_amount": "0",
+      "vesting_period": "1",
+      "vesting_increment": "70.730534765"
+    },
+    "token": "1",
+    "token_permissions": {},
+    "receipt_chain_hash": "2mzbV7WevxLuchs2dAMY4vQBS6XttnCUF8Hvks4XNBQ5qiSGGBQe",
+    "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
+    "permissions": {
+      "stake": true,
+      "edit_state": "signature",
+      "send": "signature",
+      "set_delegate": "signature",
+      "set_permissions": "signature",
+      "set_verification_key": "signature"
+    }
+  }
+]

--- a/test/fixtures/ledger_with_error.json
+++ b/test/fixtures/ledger_with_error.json
@@ -1,0 +1,26 @@
+[
+  {
+    "pk": "B62qqnZWjM68fMq7jVR19fGDnrigtYX9WZ14enXFiLZkE13WDe4aLy3",
+    "balance": "4793.953311237",
+    "delegate": "B62qorXXHv971Kvnq91TkvWsRAvMCB8yszCX6yUhpyZseKcibSZSDSF",
+    "timing": {
+      "initial_minimum_balance": "4651",
+      "cliff_time": "some wrong value",
+      "cliff_amount": "4651",
+      "vesting_period": "1",
+      "vesting_increment": "0"
+    },
+    "token": "1",
+    "token_permissions": {},
+    "receipt_chain_hash": "2mzbV7WevxLuchs2dAMY4vQBS6XttnCUF8Hvks4XNBQ5qiSGGBQe",
+    "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
+    "permissions": {
+      "stake": true,
+      "edit_state": "signature",
+      "send": "signature",
+      "set_delegate": "signature",
+      "set_permissions": "signature",
+      "set_verification_key": "signature"
+    }
+  }
+]


### PR DESCRIPTION
We've had an issue where `timing_vesting_increment` column didnt have any data after Mina launch, so we were not decoding the field correctly. It's an amount field instead of an int. 