### PR TITLE
Add CLI command to import/override ledger data

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -68,6 +68,8 @@ func startCommand(cfg *config.Config, name string) error {
 		return startStatus(cfg)
 	case "update-identity":
 		return runUpdateIdentity(cfg)
+	case "import-ledger":
+		return importLedger(cfg)
 	default:
 		return fmt.Errorf("%s is not a valid command", name)
 	}

--- a/cli/import_ledger.go
+++ b/cli/import_ledger.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"strconv"
+
+	"github.com/figment-networks/mina-indexer/client/archive"
+	"github.com/figment-networks/mina-indexer/client/graph"
+	"github.com/figment-networks/mina-indexer/config"
+	"github.com/figment-networks/mina-indexer/model/mapper"
+)
+
+func importLedger(cfg *config.Config) error {
+	store, err := initStore(cfg)
+	if err != nil {
+		return err
+	}
+
+	ledgerFile := os.Getenv("LEDGER_FILE")
+	if ledgerFile == "" {
+		return errors.New("LEDGER_FILE env var is not provided")
+	}
+
+	epochVal := os.Getenv("LEDGER_EPOCH")
+	if epochVal == "" {
+		return errors.New("LEDGER_EPOCH env var is not provided")
+	}
+
+	epoch, err := strconv.Atoi(epochVal)
+	if err != nil {
+		return err
+	}
+
+	rawData, err := decodeLedgerData(ledgerFile)
+	if err != nil {
+		return err
+	}
+
+	tip := &graph.Block{
+		ProtocolState: &graph.ProtocolState{
+			ConsensusState: &graph.ConsensusState{
+				Epoch: epochVal,
+			},
+		},
+	}
+
+	ledger, err := mapper.Ledger(tip, rawData)
+	if err != nil {
+		return nil
+	}
+
+	if err := store.Staking.DeleteEpochLedger(epoch); err != nil {
+		return err
+	}
+
+	if err := store.Staking.CreateLedger(ledger.Ledger); err != nil {
+		return err
+	}
+	ledger.UpdateLedgerID()
+
+	return store.Staking.CreateLedgerEntries(ledger.Entries)
+}
+
+func decodeLedgerData(path string) ([]archive.StakingInfo, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	result := []archive.StakingInfo{}
+	return result, json.NewDecoder(f).Decode(&result)
+}

--- a/store/staking.go
+++ b/store/staking.go
@@ -2,9 +2,10 @@ package store
 
 import (
 	"github.com/figment-networks/indexing-engine/store/bulk"
+	"github.com/jinzhu/gorm"
+
 	"github.com/figment-networks/mina-indexer/model"
 	"github.com/figment-networks/mina-indexer/store/queries"
-	"github.com/jinzhu/gorm"
 )
 
 const batchSize = 100

--- a/store/staking.go
+++ b/store/staking.go
@@ -4,6 +4,7 @@ import (
 	"github.com/figment-networks/indexing-engine/store/bulk"
 	"github.com/figment-networks/mina-indexer/model"
 	"github.com/figment-networks/mina-indexer/store/queries"
+	"github.com/jinzhu/gorm"
 )
 
 const batchSize = 100
@@ -16,6 +17,16 @@ type StakingStore struct {
 // CreateLedger creates a new ledger record
 func (s StakingStore) CreateLedger(ledger *model.Ledger) error {
 	return s.Create(ledger)
+}
+
+// DeleteEpochLedger removes ledger and all associated records for an epoch
+func (s StakingStore) DeleteEpochLedger(epoch int) error {
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec("DELETE FROM ledger_entries WHERE ledger_id = (SELECT id FROM ledgers WHERE epoch = ? LIMIT 1)", epoch).Error; err != nil {
+			return err
+		}
+		return tx.Exec("DELETE FROM ledgers WHERE epoch = ?", epoch).Error
+	})
 }
 
 // CreateLedgerEntries create a batch of ledger entries


### PR DESCRIPTION
This will delete ledger and its records and import new one.
Example usage:

```shell
export LEDGER_EPOCH=9 # actual epoch number, not internal id
export LEDGER_FILE=/path/to/file.json # full path to ledger dumb file

./mina-indexer -config=./mainnet.json -cmd=import-ledger
```