### PR TITLE
Include staking_ratio into chain stats response

### DIFF
--- a/store/queries/blocks_stats.sql
+++ b/store/queries/blocks_stats.sql
@@ -16,6 +16,7 @@ SELECT
   coinbase_amount::TEXT coinbase_amount,
   total_currency::TEXT total_currency,
   staked_amount::TEXT staked_amount,
+  ROUND(staked_amount * 100.0 / total_currency, 2) staking_ratio,
   delegations_count,
   delegations_amount::TEXT delegations_amount
 FROM


### PR DESCRIPTION
New response on `/chain_stats` or `/block_stats`:

```json
[
  {
    "time": "2021-09-30T14:00:00-05:00",
    "block_time_avg": 180,
    "blocks_count": 5,
    "validators_count": 5,
    "snarkers_count": 497,
    "jobs_count": 0,
    "jobs_amount": "0",
    "transactions_count": 26,
    "transactions_amount": "6291100247009",
    "payments_count": 16,
    "payments_amount": "1250790047009",
    "fee_transfers_count": 5,
    "fee_transfers_amount": "310200000",
    "coinbase_count": 5,
    "coinbase_amount": "5040000000000",
    "total_currency": "858434572840039233",
    "staked_amount": "853475990840038617",
    "staking_ratio": 99.42, <---- NEW
    "delegations_count": 52018,
    "delegations_amount": "853475990840038617"
  }
]
```