### PR TITLE
Force UTC time

### DIFF
--- a/model/util/time.go
+++ b/model/util/time.go
@@ -4,20 +4,20 @@ import "time"
 
 // HourInterval returns a time interval for an hour
 func HourInterval(t time.Time) (time.Time, time.Time) {
-	year, month, day := t.Date()
+	year, month, day := t.UTC().Date()
 
-	start := time.Date(year, month, day, t.Hour(), 0, 0, 0, t.Location())
-	end := time.Date(year, month, day, t.Hour(), 59, 59, 0, t.Location())
+	start := time.Date(year, month, day, t.Hour(), 0, 0, 0, time.UTC)
+	end := time.Date(year, month, day, t.Hour(), 59, 59, 0, time.UTC)
 
 	return start, end
 }
 
 // DayInterval returns a time interval for 24h
 func DayInterval(t time.Time) (time.Time, time.Time) {
-	year, month, day := t.Date()
+	year, month, day := t.UTC().Date()
 
-	start := time.Date(year, month, day, 0, 0, 0, 0, t.Location())
-	end := time.Date(year, month, day, 23, 59, 59, 0, t.Location())
+	start := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+	end := time.Date(year, month, day, 23, 59, 59, 0, time.UTC)
 
 	return start, end
 }


### PR DESCRIPTION
Should fix the bug that we were encountering.  The primary key constraint was being violated because times were not being converted correctly from non-UTC timezones when deleting database records before inserting them again, so nothing was getting deleted.

For example, here is a delete that wasn't happening because the timestamp was not getting parameterized correctly:
https://github.com/figment-networks/mina-indexer/blob/bug/force-utc-time/store/stats.go#L30-L33

It looks to have occurred because the insert query was parameterized whereas the delete was not and just cast to a timestamp.  Rather than fix this, it seems better to enforce the use of UTC time.