### PR TITLE
Skip parsing nonexistent accounts

### DIFF
--- a/client/graph/client.go
+++ b/client/graph/client.go
@@ -243,7 +243,14 @@ func (c Client) GetAccount(publicKey string) (*Account, error) {
 	if err := c.Query(buildAccountQuery(publicKey), &result); err != nil {
 		return nil, err
 	}
-	return &result.Account, nil
+
+	// the GraphQL endpoint will return a null account object for nonexistent accounts
+	// check if the required account fields are empty/nil to confirm if it's null
+	if result.Account.PublicKey == "" && result.Account.Balance == nil {
+		return nil, nil
+	} else {
+		return &result.Account, nil
+	}
 }
 
 func (c Client) ConsensusTip() (*Block, error) {

--- a/worker/sync.go
+++ b/worker/sync.go
@@ -335,6 +335,14 @@ func (w SyncWorker) fetchSeenAccounts(graphBlock *graph.Block, data *indexing.Da
 			return err
 		}
 
+		// an account may be in the block, but doesn't actually exist because of a failed account creation transaction
+		// e.g. Amount_insufficient_to_create_account
+		// skip these since the account does not exist
+		if acc == nil {
+			log.WithField("account_id", accID).Info("skipping nonexistent account")
+			continue
+		}
+
 		mappedAcc, err := mapper.Account(graphBlock, acc)
 		if err != nil {
 			return err


### PR DESCRIPTION
an account may be in the block, but doesn't actually exist because of a failed account creation transaction
e.g. Amount_insufficient_to_create_account