### PR TITLE
blocks_stats: prevent divide by zero error when total_currency is 0

### DIFF
--- a/store/queries/blocks_stats.sql
+++ b/store/queries/blocks_stats.sql
@@ -16,7 +16,7 @@ SELECT
   coinbase_amount::TEXT coinbase_amount,
   total_currency::TEXT total_currency,
   staked_amount::TEXT staked_amount,
-  ROUND(staked_amount * 100.0 / total_currency, 2) staking_ratio,
+  ROUND(staked_amount * 100.0 / NULLIF(total_currency, 0), 2) staking_ratio,
   delegations_count,
   delegations_amount::TEXT delegations_amount
 FROM


### PR DESCRIPTION
Return a NULL for staking_ratio if total_currency is 0

In the database, `SELECT 1/NULL` returns NULL